### PR TITLE
SEON-3125 - Improvements to ElasticSearch log appender:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.internetitem</groupId>
     <artifactId>logback-elasticsearch-appender</artifactId>
-    <version>1.7-SNAPSHOT</version>
+    <version>1.7-SEON</version>
     <packaging>jar</packaging>
 
     <name>Logback Elasticsearch Appender</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.internetitem</groupId>
     <artifactId>logback-elasticsearch-appender</artifactId>
-    <version>1.7-SEON</version>
+    <version>1.7.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Logback Elasticsearch Appender</name>

--- a/src/main/java/com/internetitem/logback/elasticsearch/ElasticsearchOutputAggregator.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ElasticsearchOutputAggregator.java
@@ -3,74 +3,80 @@ package com.internetitem.logback.elasticsearch;
 import com.internetitem.logback.elasticsearch.config.Settings;
 import com.internetitem.logback.elasticsearch.util.ErrorReporter;
 import com.internetitem.logback.elasticsearch.writer.SafeWriter;
-
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+
 public class ElasticsearchOutputAggregator extends Writer {
 
-	private Settings settings;
-	private ErrorReporter errorReporter;
-	private List<SafeWriter> writers;
+    private Settings settings;
+    private ErrorReporter errorReporter;
+    private List<SafeWriter> writers;
 
-	public ElasticsearchOutputAggregator(Settings settings, ErrorReporter errorReporter) {
-		this.writers = new ArrayList<SafeWriter>();
-		this.settings = settings;
-		this.errorReporter = errorReporter;
-	}
+    public ElasticsearchOutputAggregator(Settings settings, ErrorReporter errorReporter) {
+        this.writers = new ArrayList<SafeWriter>();
+        this.settings = settings;
+        this.errorReporter = errorReporter;
+    }
 
-	public void addWriter(SafeWriter writer) {
-		writers.add(writer);
-	}
+    public void addWriter(SafeWriter writer) {
+        writers.add(writer);
+    }
 
-	@Override
-	public void write(char[] cbuf, int off, int len) throws IOException {
-		for (SafeWriter writer : writers) {
-			writer.write(cbuf, off, len);
-		}
-	}
+    @Override
+    public void write(char[] cbuf, int off, int len) throws IOException {
+        for (SafeWriter writer : writers) {
+            writer.write(cbuf, off, len);
+        }
+    }
 
-	public boolean hasPendingData() {
-		for (SafeWriter writer : writers) {
-			if (writer.hasPendingData()) {
-				return true;
-			}
-		}
-		return false;
-	}
+    public boolean hasPendingData() {
+        for (SafeWriter writer : writers) {
+            if (writer.hasPendingData()) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	public boolean hasOutputs() {
-		return !writers.isEmpty();
-	}
+    public boolean hasOutputs() {
+        return !writers.isEmpty();
+    }
 
-	public boolean sendData() {
-		boolean success = true;
-		for (SafeWriter writer : writers) {
-			try {
-				writer.sendData();
-			} catch (IOException e) {
-				success = false;
-				errorReporter.logWarning("Failed to send events to Elasticsearch: " + e.getMessage());
-				if (settings.isErrorsToStderr()) {
-					System.err.println("[" + new Date().toString() + "] Failed to send events to Elasticsearch: " + e.getMessage());
-				}
+    public boolean sendData() {
+        boolean success = true;
+        for (SafeWriter writer : writers) {
+            try {
+                writer.sendData();
+            } catch (IOException e) {
+                success = false;
+                errorReporter.logWarning("Failed to send events to Elasticsearch: " + e.getMessage());
+                if (settings.isErrorsToStderr()) {
+                    System.err.println("[" + new Date().toString() + "] Failed to send events to Elasticsearch: " + e.getMessage());
+                }
 
-			}
-		}
-		return success;
-	}
+            }
+        }
+        return success;
+    }
 
-	@Override
-	public void flush() throws IOException {
-		// No-op
-	}
+    public void clear() {
+        for (SafeWriter writer : writers) {
+            writer.clear();
+        }
+    }
 
-	@Override
-	public void close() throws IOException {
-		// No-op
-	}
+    @Override
+    public void flush() throws IOException {
+        // No-op
+    }
+
+    @Override
+    public void close() throws IOException {
+        // No-op
+    }
 
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/LoggerWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/LoggerWriter.java
@@ -24,6 +24,10 @@ public class LoggerWriter implements SafeWriter {
 		// No-op
 	}
 
+	public void clear() {
+		// No-op
+	}
+
 	public boolean hasPendingData() {
 		return false;
 	}

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/SafeWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/SafeWriter.java
@@ -8,5 +8,7 @@ public interface SafeWriter {
 
 	void sendData() throws IOException;
 
+	void clear();
+
 	boolean hasPendingData();
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/StdErrWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/StdErrWriter.java
@@ -10,6 +10,10 @@ public class StdErrWriter implements SafeWriter {
 		// No-op
 	}
 
+	public void clear() {
+		// No-op
+	}
+
 	public boolean hasPendingData() {
 		return false;
 	}

--- a/src/test/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisherTest.java
+++ b/src/test/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisherTest.java
@@ -1,0 +1,217 @@
+package com.internetitem.logback.elasticsearch;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Context;
+import com.internetitem.logback.elasticsearch.config.ElasticsearchProperties;
+import com.internetitem.logback.elasticsearch.config.HttpRequestHeaders;
+import com.internetitem.logback.elasticsearch.config.Settings;
+import com.internetitem.logback.elasticsearch.util.ErrorReporter;
+import com.internetitem.logback.elasticsearch.writer.ElasticsearchWriter;
+import com.internetitem.logback.elasticsearch.writer.SafeWriter;
+import com.sun.tools.javac.util.List;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.ArrayList;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClassicElasticsearchPublisherTest {
+    private static final int MAX_REQUEST_SIZE = 5242880;
+
+    @Mock
+    private Context context;
+    @Mock
+    private Settings settings;
+    @Mock
+    ErrorReporter errorReporter;
+    @Mock
+    private ElasticsearchProperties properties;
+    @Mock
+    private HttpRequestHeaders headers;
+
+    private ClassicElasticsearchPublisher publisher;
+
+    private Field fldWorking;
+    private Field fldOutputAggregator;
+
+    @Before
+    public void setUp() throws IOException, NoSuchFieldException {
+        when(settings.getMaxQueueSize()).thenReturn(MAX_REQUEST_SIZE);
+        when(settings.getSleepTime()).thenReturn(150);
+        when(settings.getIndex()).thenReturn("logs");
+        when(settings.getType()).thenReturn("someLogs");
+        when(settings.getUrl()).thenReturn(new URL("https://my.sample.elastic"));
+        publisher = new ClassicElasticsearchPublisher(context, errorReporter, settings, properties, headers);
+        fldWorking = AbstractElasticsearchPublisher.class.getDeclaredField("working");
+        fldWorking.setAccessible(true);
+        fldOutputAggregator = AbstractElasticsearchPublisher.class.getDeclaredField("outputAggregator");
+        fldOutputAggregator.setAccessible(true);
+
+        Answer<Void> loggerAnswer = new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                String message = invocation.getArgumentAt(0, String.class);
+                System.out.println(message);
+                return null;
+            }
+        };
+        doAnswer(loggerAnswer).when(errorReporter).logWarning(anyString());
+        doAnswer(loggerAnswer).when(errorReporter).logInfo(anyString());
+    }
+
+    @Test
+    public void retry_does_not_get_stuck_if_es_fails() throws InterruptedException, IllegalAccessException, NoSuchFieldException, NoSuchMethodException, IOException {
+        // given
+
+        final boolean[] shouldStop = new boolean[]{false};
+        final boolean[] failed = new boolean[]{false};
+        final int[] maxIndex = new int[]{0, 0};
+        Thread loggingThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                long start = System.currentTimeMillis();
+                int limitPerTime = 300;
+                long timeInterval = 10;
+                int i = 1;
+                while (!shouldStop[0]) {
+                    try {
+                        ILoggingEvent event = mock(ILoggingEvent.class);
+                        when(event.getLevel()).thenReturn(Level.INFO);
+                        String currentMsg = "_____" + i + "++++" +
+                          "OuIpju4ZK7RRHLJ5VgihDFXf5yLvq8NVErzXZ6HDW2Cq1xadj";
+                        when(event.getFormattedMessage()).thenReturn(
+                          currentMsg
+                        );
+                        publisher.addEvent(event);
+                        maxIndex[0] = i;
+                        i += 1;
+                        if (i % limitPerTime == 0) {
+                            long sleepTime = start + timeInterval - System.currentTimeMillis();
+                            if (sleepTime > 0) {
+                                Thread.sleep(sleepTime);
+                            }
+                            start = System.currentTimeMillis();
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }, "Logging thread");
+        loggingThread.setPriority(Thread.MIN_PRIORITY);
+        loggingThread.start();
+        Thread.currentThread().setPriority(Thread.MAX_PRIORITY);
+
+        ElasticsearchOutputAggregator aggregator = (ElasticsearchOutputAggregator)fldOutputAggregator.get(publisher);
+        Field f = ElasticsearchOutputAggregator.class.getDeclaredField("writers");
+        f.setAccessible(true);
+        ArrayList<SafeWriter> writers = (ArrayList<SafeWriter>) f.get(aggregator);
+        final ElasticsearchWriter writer = spy((ElasticsearchWriter)writers.get(0));
+        f.set(aggregator, List.of(
+          writer
+        ));
+        mockWriterSendData(writer, maxIndex, shouldStop, failed);
+        // when
+
+        waitForPublisherThreadToStartWorking();
+
+        loggingThread.join();
+
+        waitForPublisherThreadToFinish();
+        shouldStop[0] = true;
+        if (failed[0]) {
+            Assert.fail("A critical failure occured");
+        }
+        assertEquals(maxIndex[0], maxIndex[1]);
+    }
+
+    private void mockWriterSendData(final ElasticsearchWriter writer, final int[] maxIndex, final boolean[] shouldStop, final boolean[] failed) throws NoSuchFieldException, IllegalAccessException, NoSuchMethodException, IOException {
+
+        Field fldBuffer = ElasticsearchWriter.class.getDeclaredField("sendBuffer");
+        fldBuffer.setAccessible(true);
+        Field fldBackupBuffer = ElasticsearchWriter.class.getDeclaredField("backupBuffer");
+        fldBackupBuffer.setAccessible(true);
+
+        final Field fldBufferExceeded = ElasticsearchWriter.class.getDeclaredField("bufferExceeded");
+        fldBufferExceeded.setAccessible(true);
+
+        final Method updateBuffersOnSuccess = ElasticsearchWriter.class.getDeclaredMethod("updateBuffersOnSuccess");
+        updateBuffersOnSuccess.setAccessible(true);
+
+        final StringBuilder sendBuffer = (StringBuilder)fldBuffer.get(writer);
+
+        final Long startTime = System.currentTimeMillis();
+        doAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws IllegalAccessException, InvocationTargetException {
+                String buf = sendBuffer.substring(sendBuffer.indexOf("\n") + 1, sendBuffer.indexOf("\n", sendBuffer.indexOf("\n") + 1));
+                String bufEnd = sendBuffer.substring(sendBuffer.lastIndexOf("\n", sendBuffer.lastIndexOf("\n") - 1));
+                System.out.println(sendBuffer.length());
+                System.out.println(buf + "\n..." + bufEnd);
+                if (System.currentTimeMillis() - startTime > 10000) {
+                    shouldStop[0] = true;
+                }
+                if (sendBuffer.length() > MAX_REQUEST_SIZE) {
+                    shouldStop[0] = true;
+                    failed[0] = true;
+                    throw new RuntimeException("Request too large");
+                } else if (sendBuffer.charAt(sendBuffer.length() - 1) != '\n') {
+                    shouldStop[0] = true;
+                    failed[0] = true;
+                    throw new RuntimeException("Request must end with a \n");
+                } else {
+                    maxIndex[1] = Integer.parseInt(bufEnd.substring(bufEnd.indexOf("____") + 5, bufEnd.indexOf("++++")));
+                    // System.out.println(sendBuffer.toString().substring(0, 200));
+                    updateBuffersOnSuccess.invoke(writer);
+                }
+                return null;
+            }
+        }).when(writer).sendData();
+    }
+
+    private void waitForPublisherThreadToStartWorking() throws InterruptedException, IllegalAccessException {
+        do {
+            boolean working = (boolean) fldWorking.get(publisher);
+            Thread.sleep(100);
+            if (working) {
+                break;
+            }
+        } while (true);
+    }
+
+    private void waitForPublisherThreadToFinish() throws InterruptedException, IllegalAccessException {
+        int c = 0;
+        do {
+            boolean working = (boolean) fldWorking.get(publisher);
+            Thread.sleep(100);
+            if (!working) {
+                break;
+            }
+            c += 1;
+            if (c > 100) {
+                Assert.fail("Log publisher thread is not stopping properly");
+                break;
+            }
+        } while (true);
+    }
+}

--- a/src/test/java/com/internetitem/logback/elasticsearch/ElasticsearchAppenderTest.java
+++ b/src/test/java/com/internetitem/logback/elasticsearch/ElasticsearchAppenderTest.java
@@ -43,7 +43,6 @@ public class ElasticsearchAppenderTest {
 
     @Before
     public void setUp() {
-
         appender = new ElasticsearchAppender() {
             @Override
             protected ClassicElasticsearchPublisher buildElasticsearchPublisher() throws IOException {


### PR DESCRIPTION
1. Queue size is max request size, preventing Too Large Request errors at the root
2. An in-memory buffer is kept on top of the send-buffer, to collect some logs while we are pushing to ElasticSearch. Logs are only dropped, if this backup buffer is also full
3. Writing a single log event is made to be atomic instead of possibly ending up with an arbitrary fragment (even in the middle of a JSON object) at the end of the request, again causing failure.
4. maxRetries works properly now. If we have a payload that failed, we'll try that payload maxRetries times. If we deplete max tries, we throw away that payload and start consuming the rest.
This avoids observed deadlock.
5. Added a terrifying test, which simulates a heavy-load scenario, with mocked sendData, which will throw if request is larger then maxQueueSize, or if it doesn't end with a newline.
We assert that none of these two error scenarios occur, and we also assert that if the backup buffer is not filled, then no logs are being lost.